### PR TITLE
move i declaration before for (C99)

### DIFF
--- a/i2c_master.c
+++ b/i2c_master.c
@@ -98,7 +98,8 @@ uint8_t i2c_transmit(uint8_t address, uint8_t* data, uint16_t length)
 {
 	if (i2c_start(address | I2C_WRITE)) return 1;
 	
-	for (uint16_t i = 0; i < length; i++)
+	uint16_t i;
+	for (i = 0; i < length; i++)
 	{
 		if (i2c_write(data[i])) return 1;
 	}
@@ -112,7 +113,8 @@ uint8_t i2c_receive(uint8_t address, uint8_t* data, uint16_t length)
 {
 	if (i2c_start(address | I2C_READ)) return 1;
 	
-	for (uint16_t i = 0; i < (length-1); i++)
+	uint16_t i;
+	for (i = 0; i < (length-1); i++)
 	{
 		data[i] = i2c_read_ack();
 	}
@@ -129,7 +131,8 @@ uint8_t i2c_writeReg(uint8_t devaddr, uint8_t regaddr, uint8_t* data, uint16_t l
 
 	i2c_write(regaddr);
 
-	for (uint16_t i = 0; i < length; i++)
+	uint16_t i;
+	for (i = 0; i < length; i++)
 	{
 		if (i2c_write(data[i])) return 1;
 	}
@@ -147,7 +150,8 @@ uint8_t i2c_readReg(uint8_t devaddr, uint8_t regaddr, uint8_t* data, uint16_t le
 
 	if (i2c_start(devaddr | 0x01)) return 1;
 
-	for (uint16_t i = 0; i < (length-1); i++)
+	uint16_t i;
+	for (i = 0; i < (length-1); i++)
 	{
 		data[i] = i2c_read_ack();
 	}


### PR DESCRIPTION
In file included from main.c:3:
../include/twi/i2c_master.c: In function 'i2c_transmit':
../include/twi/i2c_master.c:101: error: 'for' loop initial declaration used outside C99 mode